### PR TITLE
Newest python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie
+FROM python
 
 RUN pip install certbot certbot-s3front
 


### PR DESCRIPTION
Image can no longer be built with python 2.7.

FYI, also see #1 